### PR TITLE
Hotfix/#18 shifted by nicoad

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,8 +23,7 @@
         "scripts": ["js/background.js"]
     },
     "web_accessible_resources": [
-        "js/hack_fetch_thread.js",
-        "js/hack_get_nicoads.js"
+        "js/hack_lib.js"
     ],
     "page_action": {
         "default_popup": "",

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,8 @@
         "scripts": ["js/background.js"]
     },
     "web_accessible_resources": [
-        "js/hack_fetch_thread.js"
+        "js/hack_fetch_thread.js",
+        "js/hack_get_nicoads.js"
     ],
     "page_action": {
         "default_popup": "",

--- a/src/js/hack_fetch_thread.js
+++ b/src/js/hack_fetch_thread.js
@@ -4,7 +4,7 @@ Released under the MIT license
 https://github.com/noradium/dac/blob/master/src/scripts/hack_fetch_thread.js
 */
 
-import CmtGraph from "./lib/cmt_graph";
+import {createCmtGraph} from "./lib/cmt_graph";
 
 try {
     init();
@@ -13,7 +13,6 @@ try {
 }
 
 function init() {
-    let cmtGraph = new CmtGraph();
     const libraryFunctions = window['webpackJsonp'][0][1];
     const commentClientFunctionIndex = libraryFunctions.findIndex((item) => {
         // Now, fetchThread is the library to fetch comments
@@ -37,7 +36,7 @@ function init() {
                     // DEBUG
                     console.debug('Called hacked fetchThread');
                     // Add custom processing
-                    cmtGraph.createCmtGraph(threads);
+                    createCmtGraph(threads);
                     // Return original Promise
                     return threads;
                 }).catch((err) => {

--- a/src/js/hack_fetch_thread.js
+++ b/src/js/hack_fetch_thread.js
@@ -34,11 +34,13 @@ function init() {
             return originalFetchThread.call(this, ...arguments)
                 .then((threads) => {
                     // Add custom processing
-                    createCmtGraph(threads);
+                    try {
+                        createCmtGraph(threads);
+                    } catch (err) {
+                        console.error("[ERROR] Failed to do custom fetchThread", err);
+                    }
                     // Return original Promise
                     return threads;
-                }).catch((err) => {
-                    console.error("[ERROR] Failed to fetch thread", err);
                 });
         };
     };

--- a/src/js/hack_fetch_thread.js
+++ b/src/js/hack_fetch_thread.js
@@ -4,15 +4,16 @@ Released under the MIT license
 https://github.com/noradium/dac/blob/master/src/scripts/hack_fetch_thread.js
 */
 
-import {createCmtGraph} from "./lib/cmt_graph";
+import CmtGraph from "./lib/cmt_graph";
 
 try {
     init();
 } catch (error) {
-    console.error('[ERROR] Failed to initialize nicograph', error);
+    console.error('[ERROR] Failed to hack fetchThread function', error);
 }
 
 function init() {
+    let cmtGraph = new CmtGraph();
     const libraryFunctions = window['webpackJsonp'][0][1];
     const commentClientFunctionIndex = libraryFunctions.findIndex((item) => {
         // Now, fetchThread is the library to fetch comments
@@ -33,8 +34,11 @@ function init() {
         e.exports[fetchThreadBlockPropertyName].prototype.fetchThread = function () {
             return originalFetchThread.call(this, ...arguments)
                 .then((threads) => {
+                    // DEBUG
+                    console.debug('Called hacked fetchThread');
                     // Add custom processing
-                    createCmtGraph(threads);
+                    cmtGraph.createCmtGraph(threads);
+                    // Return original Promise
                     return threads;
                 }).catch((err) => {
                     console.error("[ERROR] Failed to fetch thread", err);

--- a/src/js/hack_fetch_thread.js
+++ b/src/js/hack_fetch_thread.js
@@ -4,7 +4,7 @@ Released under the MIT license
 https://github.com/noradium/dac/blob/master/src/scripts/hack_fetch_thread.js
 */
 
-import createCmtGraph from "./lib/create_cmt_graph";
+import {createCmtGraph} from "./lib/cmt_graph";
 
 try {
     init();
@@ -21,6 +21,7 @@ function init() {
 
     // Overwrite fetch comment library
     const originalCommentClientFunction = libraryFunctions[commentClientFunctionIndex];
+
     libraryFunctions[commentClientFunctionIndex] = function (e, t, n) {
         originalCommentClientFunction(e, t, n);
 

--- a/src/js/hack_fetch_thread.js
+++ b/src/js/hack_fetch_thread.js
@@ -33,8 +33,6 @@ function init() {
         e.exports[fetchThreadBlockPropertyName].prototype.fetchThread = function () {
             return originalFetchThread.call(this, ...arguments)
                 .then((threads) => {
-                    // DEBUG
-                    console.debug('Called hacked fetchThread');
                     // Add custom processing
                     createCmtGraph(threads);
                     // Return original Promise

--- a/src/js/hack_get_nicoads.js
+++ b/src/js/hack_get_nicoads.js
@@ -36,13 +36,16 @@ function init() {
                 .then((nicoads) => {
                     // Add custom process
                     if (nicoads) {
-                        overwriteCmtGraph({isNicoads: true});
+                        try {
+                            overwriteCmtGraph({isNicoads: true});
+                        } catch (err) {
+                            console.error("[ERROR] Failed to do custom getNicoads", err);
+                        }
                     }
                     // Return original Promise
                     return nicoads;
-                }).catch((err) => {
-                    console.error("[ERROR] Failed to get nicoads", err);
                 });
+            
         }
     };
 }

--- a/src/js/hack_get_nicoads.js
+++ b/src/js/hack_get_nicoads.js
@@ -1,0 +1,31 @@
+try {
+    init();
+} catch (error) {
+    console.error('[ERROR] Failed to initialize nicograph', error);
+}
+
+function init() {
+    const libraryFunctions = window['webpackJsonp'][0][1];
+    const getNicoadsFunctionIndex = libraryFunctions.findIndex((item) => {
+        return item && !!item.toString().match(/\.getNicoads\s?=\s?function/);
+    });
+
+    // Overwrite get nicoads library
+    const originalGetNicoadsFunction = libraryFunctions[getNicoadsFunctionIndex];
+    libraryFunctions[getNicoadsFunctionIndex] = function (e, t, n) {
+        //originalGetNicoadsFunction(e, t, n);
+
+        const getNicoadsBlockPropertyName = Object.getOwnPropertyNames(e.exports).find((propertyName) => {
+            return e.exports[propertyName].prototype && typeof e.exports[propertyName].prototype.getNicoads === 'function';
+        });
+        const originalGetNicoads = e.exports[getNicoadsBlockPropertyName].prototype.getNicoads;
+
+        e.exports[getNicoadsBlockPropertyName].prototype.getNicoads = function () {
+            console.log(`[DEBUG] Called hacked getNicoads fucntion`);
+            let a = originalGetNicoads.call(this, ...arguments);
+            console.log(a);
+            return a;
+        };
+    };
+}
+

--- a/src/js/hack_get_nicoads.js
+++ b/src/js/hack_get_nicoads.js
@@ -4,7 +4,7 @@ Released under the MIT license
 https://github.com/noradium/dac/blob/master/src/scripts/hack_fetch_thread.js
 */
 
-import CmtGraph from "./lib/cmt_graph";
+import {overwriteCmtGraph} from "./lib/cmt_graph";
 
 try {
     init();
@@ -13,7 +13,6 @@ try {
 }
 
 function init() {
-    let cmtGraph = new CmtGraph();
     const libraryFunctions = window['webpackJsonp'][0][1];
     const nicoadsModuleIndex = libraryFunctions.findIndex((item) => {
         return item && !!item.toString().match(/\.getNicoads\s?=\s?function/);
@@ -40,7 +39,7 @@ function init() {
                     console.debug(val);
                     // Add custom process
                     if (val) {
-                        cmtGraph.overwriteCmtGraph({isNicoads: true});
+                        overwriteCmtGraph({isNicoads: true});
                     }
                     // Return original Promise
                     return val;

--- a/src/js/hack_get_nicoads.js
+++ b/src/js/hack_get_nicoads.js
@@ -1,3 +1,11 @@
+/*
+Copyright (c) 2017 noradium
+Released under the MIT license
+https://github.com/noradium/dac/blob/master/src/scripts/hack_fetch_thread.js
+*/
+
+import {setNicoads} from "./lib/cmt_graph";
+
 try {
     init();
 } catch (error) {
@@ -6,26 +14,33 @@ try {
 
 function init() {
     const libraryFunctions = window['webpackJsonp'][0][1];
-    const getNicoadsFunctionIndex = libraryFunctions.findIndex((item) => {
+    const nicoadsModuleIndex = libraryFunctions.findIndex((item) => {
         return item && !!item.toString().match(/\.getNicoads\s?=\s?function/);
     });
 
-    // Overwrite get nicoads library
-    const originalGetNicoadsFunction = libraryFunctions[getNicoadsFunctionIndex];
-    libraryFunctions[getNicoadsFunctionIndex] = function (e, t, n) {
-        //originalGetNicoadsFunction(e, t, n);
+    // Overwrite the library that includes getNicoads function
+    const originalNicoadsModule = libraryFunctions[nicoadsModuleIndex];
 
+    libraryFunctions[nicoadsModuleIndex] = function (e, t, n) {
+        originalNicoadsModule(e, t, n);
+
+        // Find getNicoads function
         const getNicoadsBlockPropertyName = Object.getOwnPropertyNames(e.exports).find((propertyName) => {
-            return e.exports[propertyName].prototype && typeof e.exports[propertyName].prototype.getNicoads === 'function';
+            return e.exports[propertyName].Client.prototype && typeof e.exports[propertyName].Client.prototype.getNicoads === 'function';
         });
-        const originalGetNicoads = e.exports[getNicoadsBlockPropertyName].prototype.getNicoads;
+        const originalGetNicoadsFunction = e.exports[getNicoadsBlockPropertyName].Client.prototype.getNicoads;
 
-        e.exports[getNicoadsBlockPropertyName].prototype.getNicoads = function () {
-            console.log(`[DEBUG] Called hacked getNicoads fucntion`);
-            let a = originalGetNicoads.call(this, ...arguments);
-            console.log(a);
-            return a;
-        };
+        // Overwrite getNicoads function
+        e.exports[getNicoadsBlockPropertyName].Client.prototype.getNicoads = function () {
+            return originalGetNicoadsFunction.call(this, ...arguments).then((val) => {
+                // Add custom process
+                val ? setNicoads(true) : setNicoads(false);
+
+                // Return original Promise
+                return new Promise((resolve, reject) => {
+                    resolve(val);
+                });
+            });
+        }
     };
 }
-

--- a/src/js/hack_get_nicoads.js
+++ b/src/js/hack_get_nicoads.js
@@ -33,16 +33,13 @@ function init() {
         // Overwrite getNicoads function
         e.exports[getNicoadsBlockPropertyName].Client.prototype.getNicoads = function () {
             return originalGetNicoadsFunction.call(this, ...arguments)
-                .then((val) => {
-                    // DEBUG
-                    console.debug('Called hacked getNicoads');
-                    console.debug(val);
+                .then((nicoads) => {
                     // Add custom process
-                    if (val) {
+                    if (nicoads) {
                         overwriteCmtGraph({isNicoads: true});
                     }
                     // Return original Promise
-                    return val;
+                    return nicoads;
                 }).catch((err) => {
                     console.error("[ERROR] Failed to get nicoads", err);
                 });

--- a/src/js/hack_get_nicoads.js
+++ b/src/js/hack_get_nicoads.js
@@ -4,15 +4,16 @@ Released under the MIT license
 https://github.com/noradium/dac/blob/master/src/scripts/hack_fetch_thread.js
 */
 
-import {setNicoads} from "./lib/cmt_graph";
+import CmtGraph from "./lib/cmt_graph";
 
 try {
     init();
 } catch (error) {
-    console.error('[ERROR] Failed to initialize nicograph', error);
+    console.error('[ERROR] Failed to hack getNicoads function', error);
 }
 
 function init() {
+    let cmtGraph = new CmtGraph();
     const libraryFunctions = window['webpackJsonp'][0][1];
     const nicoadsModuleIndex = libraryFunctions.findIndex((item) => {
         return item && !!item.toString().match(/\.getNicoads\s?=\s?function/);
@@ -32,15 +33,20 @@ function init() {
 
         // Overwrite getNicoads function
         e.exports[getNicoadsBlockPropertyName].Client.prototype.getNicoads = function () {
-            return originalGetNicoadsFunction.call(this, ...arguments).then((val) => {
-                // Add custom process
-                val ? setNicoads(true) : setNicoads(false);
-
-                // Return original Promise
-                return new Promise((resolve, reject) => {
-                    resolve(val);
+            return originalGetNicoadsFunction.call(this, ...arguments)
+                .then((val) => {
+                    // DEBUG
+                    console.debug('Called hacked getNicoads');
+                    console.debug(val);
+                    // Add custom process
+                    if (val) {
+                        cmtGraph.overwriteCmtGraph({isNicoads: true});
+                    }
+                    // Return original Promise
+                    return val;
+                }).catch((err) => {
+                    console.error("[ERROR] Failed to get nicoads", err);
                 });
-            });
         }
     };
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,8 +4,6 @@ Released under the MIT license
 https://github.com/noradium/dac/blob/master/src/scripts/index.js
 */
 
-//inject(chrome.extension.getURL('js/hack_fetch_thread.js'));
-//inject(chrome.extension.getURL('js/hack_get_nicoads.js'));
 inject(chrome.extension.getURL('js/hack_lib.js'));
 const watchAppJsURI = getWatchAppJsURI();
 inject(`${watchAppJsURI}${watchAppJsURI.indexOf('?') === -1 ? '?' : '&'}by-nicograph`);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,8 +4,9 @@ Released under the MIT license
 https://github.com/noradium/dac/blob/master/src/scripts/index.js
 */
 
-inject(chrome.extension.getURL('js/hack_fetch_thread.js'));
-inject(chrome.extension.getURL('js/hack_get_nicoads.js'));
+//inject(chrome.extension.getURL('js/hack_fetch_thread.js'));
+//inject(chrome.extension.getURL('js/hack_get_nicoads.js'));
+inject(chrome.extension.getURL('js/hack_lib.js'));
 const watchAppJsURI = getWatchAppJsURI();
 inject(`${watchAppJsURI}${watchAppJsURI.indexOf('?') === -1 ? '?' : '&'}by-nicograph`);
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,6 +5,7 @@ https://github.com/noradium/dac/blob/master/src/scripts/index.js
 */
 
 inject(chrome.extension.getURL('js/hack_fetch_thread.js'));
+inject(chrome.extension.getURL('js/hack_get_nicoads.js'));
 const watchAppJsURI = getWatchAppJsURI();
 inject(`${watchAppJsURI}${watchAppJsURI.indexOf('?') === -1 ? '?' : '&'}by-nicograph`);
 

--- a/src/js/lib/cmt_graph.js
+++ b/src/js/lib/cmt_graph.js
@@ -1,4 +1,10 @@
-import cmtGraphGlobals from './cmt_graph_globals';
+let cmtGraphComp = {
+    vposMsList: [],
+    movieTimeMs: 0,
+    isNicoads: false,
+    divNum: 0,
+    resizeObserver: null
+};
 
 function extractVposMsList(threads) {
     let vposMsList = [];
@@ -87,8 +93,8 @@ function drawGraph(drawTgt, cmtCnts) {
     graphElem.appendChild(frag);
 }
 
-function addRedrawJobOnResize(drawTgt) {
-    const observer = new ResizeObserver((entries) => {
+function createResizeObserverToRedraw(drawTgt) {
+    const observer = new ResizeObserver(() => {
         let curWidth = drawTgt.getBoundingClientRect().width;
         // Re-draw
         let cmtElems = document.getElementsByClassName('CmtRect');
@@ -96,13 +102,10 @@ function addRedrawJobOnResize(drawTgt) {
         for (let e of cmtElems) {
             e.style.width = baseWidth + 'px';
         }
-        entries;    // For ESLint no-unused-vars
-
-        console.debug(debugGlobals.a);
-        debugGlobals.a++;
-        console.debug(debugGlobals.a);
     });
     observer.observe(drawTgt);
+
+    return observer;
 }
 
 // If already drawn graph, reconstruct one
@@ -111,48 +114,31 @@ function keepCmtGraph(cmtCnts) {
     let drawTgt = document.getElementsByClassName('XSlider')[0];
 
     drawGraph(drawTgt, cmtCnts);
-    addRedrawJobOnResize(drawTgt);
+    if (!cmtGraphComp.resizeObserver) {
+        let resizeObserver = createResizeObserverToRedraw(drawTgt);
+        cmtGraphComp.resizeObserver = resizeObserver;
+    }
 }
 
-let debugGlobals = {
-    a: 10,
-    b: 15
-};
-
 export function overwriteCmtGraph({
-    vposMsList  = cmtGraphGlobals.vposMsList,
-    movieTimeMs = cmtGraphGlobals.movieTimeMs,
-    isNicoads   = cmtGraphGlobals.isNicoads,
-    divNum      = cmtGraphGlobals.divNum
+    vposMsList  = cmtGraphComp.vposMsList,
+    movieTimeMs = cmtGraphComp.movieTimeMs,
+    isNicoads   = cmtGraphComp.isNicoads,
+    divNum      = cmtGraphComp.divNum
 }) {
-    console.debug(`Called overwrite`);
-    // console.debug(`vposMsList: ${vposMsList}`);
-    console.debug(`movieTimeMs: ${movieTimeMs}`);
-    console.debug(`isNicoads: ${isNicoads}`);
-    console.debug(`divNum: ${divNum}`);
-
-    console.debug('before cmtGraphGlobals:');
-    console.debug(JSON.stringify(cmtGraphGlobals));
     // Preserve vars for recreating graph
-    cmtGraphGlobals.movieTimeMs = movieTimeMs;
-    cmtGraphGlobals.vposMsList  = vposMsList;
-    cmtGraphGlobals.isNicoads   = isNicoads;
-    cmtGraphGlobals.divNum      = divNum;
-    console.debug('after cmtGraphGlobals:');
-    console.debug(JSON.stringify(cmtGraphGlobals));
+    cmtGraphComp.movieTimeMs = movieTimeMs;
+    cmtGraphComp.vposMsList  = vposMsList;
+    cmtGraphComp.isNicoads   = isNicoads;
+    cmtGraphComp.divNum      = divNum;
 
     const cmtCnts = aggrCmtCnts(vposMsList, movieTimeMs, isNicoads, divNum);
     keepCmtGraph(cmtCnts);
-
-    console.debug(debugGlobals.a);
-    debugGlobals.a++;
-    console.debug(debugGlobals.a);
 }
 
 export function createCmtGraph(threads) {
     // [ToDo]
     // Get movie time from default called library
-    console.debug(`Called createCmtGraph`);
 
     // Loop in case PlayerPlayTime-duration value is not updated yet
     let timer = setInterval(() => {
@@ -171,6 +157,4 @@ export function createCmtGraph(threads) {
             clearInterval(timer);
         }
     }, 100);
-
-    console.debug(debugGlobals.a);
 }

--- a/src/js/lib/cmt_graph.js
+++ b/src/js/lib/cmt_graph.js
@@ -1,24 +1,5 @@
-export default function createCmtGraph(threads) {
-    // [ToDo]
-    // Get movie time from default called library
-
-    // Loop in case PlayerPlayTime-duration value is not updated yet
-    let timer = setInterval(() => {
-        // Get movie duration from document
-        let movieDuration = document.getElementsByClassName(
-            'PlayTimeFormatter PlayerPlayTime-duration')[0].innerHTML;
-
-        // PlayerPlayTime-document value is updated
-        if (movieDuration && movieDuration !== '00:00') {
-            let durs = movieDuration.split(':');
-            let movieTimeMs = (parseInt(durs[0]) * 60 + parseInt(durs[1])) * 1000;
-
-            const cmtCnts = aggrCmtCnts(threads, movieTimeMs);
-            keepCmtGraph(cmtCnts);
-
-            clearInterval(timer);
-        }
-    }, 100);
+let shareVars = {
+    isNicoads: null
 }
 
 function aggrCmtCnts(threads, movieTimeMs, divNum = 100) {
@@ -35,21 +16,15 @@ function aggrCmtCnts(threads, movieTimeMs, divNum = 100) {
     let cmtCnts = new Array(divNum);
     cmtCnts.fill(0);
 
-    // [Todo] Adapt to AdBlock
-    /*
-    // Check either display niconico advertisement or not
-    let adsTime = 0;
-    if (videoId) {
-        if (jsonAds.data.activePoint > 0) {
-            adsTime = 10*100;
-        }
+    // Nicoads time at the movie end
+    let nicoadsTimeMs = 0;
+    if (shareVars.isNicoads) {
+        nicoadsTimeMs = 10*1000;
     }
-    */
 
-    let baseTimeMs = movieTimeMs / divNum;
-    //let baseTime = (movieTime + adsTime) / divNum;
+    let intervalTimeMs = (movieTimeMs + nicoadsTimeMs) / divNum;
     vposMs.forEach((timeMs) => {
-        let p = parseInt(timeMs / baseTimeMs);
+        let p = parseInt(timeMs / intervalTimeMs);
         if (p >= divNum) p = divNum - 1;
         cmtCnts[p] += 1;
     });
@@ -57,6 +32,7 @@ function aggrCmtCnts(threads, movieTimeMs, divNum = 100) {
     return cmtCnts;
 }
 
+// If already drawn graph, reconstruct one
 function keepCmtGraph(cmtCnts) {
     // Draw graph over seekbar
     let drawTgt = document.getElementsByClassName('XSlider')[0];
@@ -128,4 +104,31 @@ function addRedrawJobOnResize(drawTgt) {
         entries;    // For ESLint no-unused-vars
     });
     observer.observe(drawTgt);
+}
+
+export function setNicoads(isExist) {
+    shareVars.isNicoads = isExist;
+}
+
+export function createCmtGraph(threads) {
+    // [ToDo]
+    // Get movie time from default called library
+
+    // Loop in case PlayerPlayTime-duration value is not updated yet
+    let timer = setInterval(() => {
+        // Get movie duration from document
+        let movieDuration = document.getElementsByClassName(
+            'PlayTimeFormatter PlayerPlayTime-duration')[0].innerHTML;
+
+        // PlayerPlayTime-document value is updated
+        if (movieDuration && movieDuration !== '00:00') {
+            let durs = movieDuration.split(':');
+            let movieTimeMs = (parseInt(durs[0]) * 60 + parseInt(durs[1])) * 1000;
+
+            let cmtCnts = aggrCmtCnts(threads, movieTimeMs);
+            keepCmtGraph(cmtCnts);
+
+            clearInterval(timer);
+        }
+    }, 100);
 }

--- a/src/js/lib/cmt_graph.js
+++ b/src/js/lib/cmt_graph.js
@@ -1,3 +1,5 @@
+import cmtGraphGlobals from './cmt_graph_globals';
+
 function extractVposMsList(threads) {
     let vposMsList = [];
     threads.forEach((thread) => {
@@ -95,6 +97,10 @@ function addRedrawJobOnResize(drawTgt) {
             e.style.width = baseWidth + 'px';
         }
         entries;    // For ESLint no-unused-vars
+
+        console.debug(debugGlobals.a);
+        debugGlobals.a++;
+        console.debug(debugGlobals.a);
     });
     observer.observe(drawTgt);
 }
@@ -108,40 +114,42 @@ function keepCmtGraph(cmtCnts) {
     addRedrawJobOnResize(drawTgt);
 }
 
-export default function cmtGraph() {
-    this.shareVars = {
-        vposMsList: [],
-        movieTimeMs: 0,
-        isNicoads: false,
-        divNum: 0
-    };
-}
+let debugGlobals = {
+    a: 10,
+    b: 15
+};
 
-cmtGraph.prototype.overwriteCmtGraph = function({
-    vposMsList  = this.shareVars.vposMsList,
-    movieTimeMs = this.shareVars.movieTimeMs,
-    isNicoads   = this.shareVars.isNicoads,
-    divNum      = this.shareVars.divNum
+export function overwriteCmtGraph({
+    vposMsList  = cmtGraphGlobals.vposMsList,
+    movieTimeMs = cmtGraphGlobals.movieTimeMs,
+    isNicoads   = cmtGraphGlobals.isNicoads,
+    divNum      = cmtGraphGlobals.divNum
 }) {
-    console.debug(`Called overwriteCmtGraph`);
-    console.debug(`vposMsList: ${vposMsList}`);
+    console.debug(`Called overwrite`);
+    // console.debug(`vposMsList: ${vposMsList}`);
     console.debug(`movieTimeMs: ${movieTimeMs}`);
     console.debug(`isNicoads: ${isNicoads}`);
     console.debug(`divNum: ${divNum}`);
 
-    console.debug(this.shareVars);
+    console.debug('before cmtGraphGlobals:');
+    console.debug(JSON.stringify(cmtGraphGlobals));
     // Preserve vars for recreating graph
-    this.shareVars.movieTimeMs = movieTimeMs;
-    this.shareVars.vposMsList  = vposMsList;
-    this.shareVars.isNicoads   = isNicoads;
-    this.shareVars.divNum      = divNum;
-    console.debug(this.shareVars);
+    cmtGraphGlobals.movieTimeMs = movieTimeMs;
+    cmtGraphGlobals.vposMsList  = vposMsList;
+    cmtGraphGlobals.isNicoads   = isNicoads;
+    cmtGraphGlobals.divNum      = divNum;
+    console.debug('after cmtGraphGlobals:');
+    console.debug(JSON.stringify(cmtGraphGlobals));
 
     const cmtCnts = aggrCmtCnts(vposMsList, movieTimeMs, isNicoads, divNum);
     keepCmtGraph(cmtCnts);
+
+    console.debug(debugGlobals.a);
+    debugGlobals.a++;
+    console.debug(debugGlobals.a);
 }
 
-cmtGraph.prototype.createCmtGraph = function(threads) {
+export function createCmtGraph(threads) {
     // [ToDo]
     // Get movie time from default called library
     console.debug(`Called createCmtGraph`);
@@ -158,9 +166,11 @@ cmtGraph.prototype.createCmtGraph = function(threads) {
             const movieTimeMs = (parseInt(durs[0]) * 60 + parseInt(durs[1])) * 1000;
 
             const vposMsList = extractVposMsList(threads);
-            this.overwriteCmtGraph({vposMsList: vposMsList, movieTimeMs: movieTimeMs, divNum: 100});
+            overwriteCmtGraph({vposMsList: vposMsList, movieTimeMs: movieTimeMs, divNum: 100});
 
             clearInterval(timer);
         }
     }, 100);
+
+    console.debug(debugGlobals.a);
 }

--- a/src/js/lib/cmt_graph_globals.js
+++ b/src/js/lib/cmt_graph_globals.js
@@ -1,0 +1,6 @@
+export default {
+    vposMsList: [],
+    movieTimeMs: 0,
+    isNicoads: false,
+    divNum: 0
+};

--- a/src/js/lib/cmt_graph_globals.js
+++ b/src/js/lib/cmt_graph_globals.js
@@ -1,6 +1,0 @@
-export default {
-    vposMsList: [],
-    movieTimeMs: 0,
-    isNicoads: false,
-    divNum: 0
-};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,16 +1,28 @@
 module.exports = {
     entry: {
         index: './src/js/index.js',
-        hack_fetch_thread: './src/js/hack_fetch_thread.js',
-        hack_get_nicoads: './src/js/hack_get_nicoads.js',
+        //hack_fetch_thread: './src/js/hack_fetch_thread.js',
+        //hack_get_nicoads: './src/js/hack_get_nicoads.js',
+        hack_lib: [
+            './src/js/hack_fetch_thread.js',
+            './src/js/hack_get_nicoads.js'
+        ],
         background: './src/js/background.js'
     },
     output: {
         filename: '[name].js'
     },
+    /*
     optimization: {
         splitChunks: {
-            chunks: 'all',
+            cacheGroups: {
+                cmt_graph: {
+                    name: 'cmt_graph',
+                    chunks: 'all',
+                    enforce: true
+                }
+            }
         },
     }
+    */
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,5 +7,10 @@ module.exports = {
     },
     output: {
         filename: '[name].js'
+    },
+    optimization: {
+        splitChunks: {
+            chunks: 'all',
+        },
     }
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -2,6 +2,7 @@ module.exports = {
     entry: {
         index: './src/js/index.js',
         hack_fetch_thread: './src/js/hack_fetch_thread.js',
+        hack_get_nicoads: './src/js/hack_get_nicoads.js',
         background: './src/js/background.js'
     },
     output: {


### PR DESCRIPTION
Close #18 
既存ライブラリ関数getNicoadsをfetchThreadと同様に書き換えることで広告有無を取得するよう対応．
ただし，取得した情報を上記2ライブラリ間で共有するためにクロージャを利用しようとしたが，injectした2つのjsソース間ではクロージャが機能しなかった（変数が共有されなかった）．そこで，webpack側で2ソースを結合出力し，injectで1ソースを指定することで対応．